### PR TITLE
Fixed bad substitution

### DIFF
--- a/inline_scan.sh
+++ b/inline_scan.sh
@@ -317,7 +317,7 @@ get_and_validate_images() {
     done
 
     # Give error message on any invalid image names
-    if [[ "${#FAILED_IMAGES[@]:-}" -gt 0 ]]; then
+    if [[ "${#FAILED_IMAGES[@]}" -gt 0 ]]; then
         printf '\n%s\n\n' "WARNING - Please pull remote image, or build/tag all local images before attempting analysis again" >&2
 
         if [[ "${#FAILED_IMAGES[@]}" -ge "${#IMAGE_NAMES[@]}" ]]; then


### PR DESCRIPTION
*Bash Version*: */usr/local/Cellar/bash/5.0.11*

```
$ /usr/local/bin/bash ./inline_scan.sh analyze -s https://secure-staging3.sysdig.com -k a150a1bf-6fdf-46d1-bf94-de13602eb8c6 -g alpine:3.8

WARNING - Please pull remote image, or build/tag all local images before attempting analysis again


        ERROR - no local docker images specified in script input: inline_scan.sh alpine:3.8


Sysdig Inline Scanner/Analyzer --

  Wrapper script for performing vulnerability scan or image analysis on local docker images, utilizing the Sysdig inline_scan container.
  For more detailed usage instructions use the -h option after specifying scan or analyze.

    Usage: inline_scan.sh <scan|analyze> [ OPTIONS ]

```

```
$ /usr/local/bin/bash ./inline_scan.sh scan alpine:3.8

WARNING - Please pull remote image, or build/tag all local images before attempting analysis again


        ERROR - no local docker images specified in script input: inline_scan.sh alpine:3.8


Sysdig Inline Scanner/Analyzer --

  Wrapper script for performing vulnerability scan or image analysis on local docker images, utilizing the Sysdig inline_scan container.
  For more detailed usage instructions use the -h option after specifying scan or analyze.

    Usage: inline_scan.sh <scan|analyze> [ OPTIONS ]

```
