### PR TITLE
Some fixes in README an help for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # secure-inline-scan
 
-This script is useful for performing image analysis on locally built container image and post the result of the analysis to sysdig secure. The only dependency for this script is access to docker-engine, Sysdig Secure endpoint (with the API token) and network connectivity to post image analysis results.
+This script is useful for performing image analysis on locally built container image and post the result of the analysis to [Sysdig Secure](https://sysdig.com/products/kubernetes-security/). The only dependency for this script is access to docker-engine, Sysdig Secure endpoint (with the API token) and network connectivity to post image analysis results.
 
 ## Usage
 
@@ -8,7 +8,7 @@ This script is useful for performing image analysis on locally built container i
     
     Sysdig Inline Scanner/Analyzer --
     
-      Wrapper script for performing vulnerability scan or image analysis on local docker images, utilizing the Sysdig inline_scan container.
+      Wrapper script for performing vulnerability scan or image analysis on local container images, utilizing the Sysdig inline_scan container.
       For more detailed usage instructions use the -h option after specifying scan or analyze.
     
         Usage: inline_scan.sh <analyze> [ OPTIONS ]
@@ -20,7 +20,7 @@ This script is useful for performing image analysis on locally built container i
 
 Sysdig Inline Analyzer --
 
-  Script for performing analysis on local docker images, utilizing the Sysdig analyzer subsystem.
+  Script for performing analysis on local container images, utilizing the Sysdig analyzer subsystem.
   After image is analyzed, the resulting image archive is sent to a remote Sysdig installation
   using the -s <URL> option. This allows inline analysis data to be persisted & utilized for reporting.
 
@@ -28,14 +28,14 @@ Sysdig Inline Analyzer --
 
     Usage: inline_scan.sh analyze -s <SYSDIG_REMOTE_URL> -k <API Token> [ OPTIONS ] <FULL_IMAGE_TAG>
 
-      -s <TEXT>  [required] URL to Sysdig Secure URL (ex: -s 'https://secure-sysdig.com')
+      -s <TEXT>  [required] Sysdig Secure URL (ex: -s 'https://secure-sysdig.svc.cluster.local')
       -k <TEXT>  [required] API token for Sysdig Scanning auth (ex: -k '924c7ddc-4c09-4d22-bd52-2f7db22f3066')
       -a <TEXT>  [optional] Add annotations (ex: -a 'key=value,key=value')
       -f <PATH>  [optional] Path to Dockerfile (ex: -f ./Dockerfile)
       -i <TEXT>  [optional] Specify image ID used within Sysdig (ex: -i '<64 hex characters>')
       -d <PATH>  [optional] Specify image digest (ex: -d 'sha256:<64 hex characters>')
       -m <PATH>  [optional] Path to Docker image manifest (ex: -m ./manifest.json)
-      -P  [optional] Pull docker image from registry
+      -P  [optional] Pull container image from registry
       -V  [optional] Increase verbosity
 
   

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Sysdig Inline Analyzer --
 
     Usage: inline_scan.sh analyze -s <SYSDIG_REMOTE_URL> -k <API Token> [ OPTIONS ] <FULL_IMAGE_TAG>
 
-      -s <TEXT>  [required] Sysdig Secure URL (ex: -s 'https://secure-sysdig.svc.cluster.local')
       -k <TEXT>  [required] API token for Sysdig Scanning auth (ex: -k '924c7ddc-4c09-4d22-bd52-2f7db22f3066')
+      -s <TEXT>  [optional] Sysdig Secure URL (ex: -s 'https://secure-sysdig.svc.cluster.local'). 
+                 If not specified, it will default to Sysdig Secure SaaS URL (https://secure.sysdig.com/).
       -a <TEXT>  [optional] Add annotations (ex: -a 'key=value,key=value')
       -f <PATH>  [optional] Path to Dockerfile (ex: -f ./Dockerfile)
       -i <TEXT>  [optional] Specify image ID used within Sysdig (ex: -i '<64 hex characters>')
@@ -61,7 +62,7 @@ Sysdig Inline Analyzer --
     [MainThread] [anchore_manager.cli.analyzers/exec()] [INFO] using fulltag=docker.io/alpine:latest fulldigest=docker.io/alpine@sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb
      Analysis complete!
     
-    Sending analysis archive to https://secure-staging.sysdig.com/api/scanning/v1
+    Sending analysis archive to https://secure.sysdig.com/api/scanning/v1
     Scan Report - 
     {
       "imageDigest": "sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb",

--- a/inline_scan.sh
+++ b/inline_scan.sh
@@ -55,7 +55,7 @@ cat << EOF
 
 Sysdig Inline Analyzer --
 
-  Script for performing analysis on local docker images, utilizing the Sysdig analyzer subsystem.
+  Script for performing analysis on local container images, utilizing the Sysdig analyzer subsystem.
   After image is analyzed, the resulting image archive is sent to a remote Sysdig installation
   using the -s <URL> option. This allows inline analysis data to be persisted & utilized for reporting.
 
@@ -63,14 +63,14 @@ Sysdig Inline Analyzer --
 
     Usage: ${0##*/} analyze -s <SYSDIG_REMOTE_URL> -k <API Token> [ OPTIONS ] <FULL_IMAGE_TAG>
 
-      -s <TEXT>  [required] URL to Sysdig Secure URL (ex: -s 'https://secure-sysdig.com')
+      -s <TEXT>  [required] Sysdig Secure URL (ex: -s 'https://secure-sysdig.svc.cluster.local')
       -k <TEXT>  [required] API token for Sysdig Scanning auth (ex: -k '924c7ddc-4c09-4d22-bd52-2f7db22f3066')
       -a <TEXT>  [optional] Add annotations (ex: -a 'key=value,key=value')
       -f <PATH>  [optional] Path to Dockerfile (ex: -f ./Dockerfile)
       -i <TEXT>  [optional] Specify image ID used within Sysdig (ex: -i '<64 hex characters>')
       -d <PATH>  [optional] Specify image digest (ex: -d 'sha256:<64 hex characters>')
       -m <PATH>  [optional] Path to Docker image manifest (ex: -m ./manifest.json)
-      -P  [optional] Pull docker image from registry
+      -P  [optional] Pull container image from registry
       -V  [optional] Increase verbosity
 
 EOF

--- a/inline_scan.sh
+++ b/inline_scan.sh
@@ -27,7 +27,7 @@ POLICY_BUNDLE="./policy_bundle.json"
 TIMEOUT=300
 VOLUME_PATH="/tmp/"
 # Analyzer option variable defaults
-SYSDIG_BASE_SCANNING_URL=''
+SYSDIG_BASE_SCANNING_URL="https://secure.sysdig.com"
 SYSDIG_SCANNING_URL="http://localhost:9040/api/scanning"
 SYSDIG_ANCHORE_URL="http://localhost:9040/api/scanning/v1/anchore"
 SYSDIG_ANNOTATIONS="foo=bar"
@@ -61,10 +61,11 @@ Sysdig Inline Analyzer --
 
   Images should be built & tagged locally.
 
-    Usage: ${0##*/} analyze -s <SYSDIG_REMOTE_URL> -k <API Token> [ OPTIONS ] <FULL_IMAGE_TAG>
+    Usage: ${0##*/} analyze -k <API Token> [ OPTIONS ] <FULL_IMAGE_TAG>
 
-      -s <TEXT>  [required] Sysdig Secure URL (ex: -s 'https://secure-sysdig.svc.cluster.local')
       -k <TEXT>  [required] API token for Sysdig Scanning auth (ex: -k '924c7ddc-4c09-4d22-bd52-2f7db22f3066')
+      -s <TEXT>  [optional] Sysdig Secure URL (ex: -s 'https://secure-sysdig.svc.cluster.local'). 
+                 If not specified, it will default to Sysdig Secure SaaS URL (https://secure.sysdig.com/).
       -a <TEXT>  [optional] Add annotations (ex: -a 'key=value,key=value')
       -f <PATH>  [optional] Path to Dockerfile (ex: -f ./Dockerfile)
       -i <TEXT>  [optional] Specify image ID used within Sysdig (ex: -i '<64 hex characters>')
@@ -102,10 +103,10 @@ main() {
 
 get_and_validate_analyzer_options() {
     #Parse options
-    while getopts ':s:k:r:u:p:a:d:f:i:m:t:PgVh' option; do
+    while getopts ':k:s:r:u:p:a:d:f:i:m:t:PgVh' option; do
         case "${option}" in
-            s  ) s_flag=true; SYSDIG_BASE_SCANNING_URL="${OPTARG%%}";;
             k  ) k_flag=true; SYSDIG_API_TOKEN="${OPTARG}";;
+            s  ) s_flag=true; SYSDIG_BASE_SCANNING_URL="${OPTARG%%}";;
             a  ) a_flag=true; SYSDIG_ANNOTATIONS="${OPTARG}";;
             f  ) f_flag=true; DOCKERFILE="${OPTARG}";;
             i  ) i_flag=true; SYSDIG_IMAGE_ID="${OPTARG}";;
@@ -133,10 +134,6 @@ get_and_validate_analyzer_options() {
         exit 1
     elif [[ "${#@}" -lt 1 ]]; then
         printf '\n\t%s\n\n' "ERROR - must specify an image to analyze" >&2
-        display_usage_analyzer >&2
-        exit 1
-    elif [[ ! "${s_flag:-}" ]]; then
-        printf '\n\t%s\n\n' "ERROR - must provide a Sysdig Secure endpoint" >&2
         display_usage_analyzer >&2
         exit 1
     elif [[ "${s_flag:-}" ]] && [[ ! "${k_flag:-}" ]]; then


### PR DESCRIPTION
After some reviews in Sysdig Scan Github Action, some changes were made in the Action README to some fragments or text that are reused from inline_scan.sh script:

https://github.com/sysdiglabs/scan-action/commit/7ee2ba007447e8de5b0a62a0c8ee604d71b790d3

Porting this fixes to the inline_scan.sh script for consistency.