### PR TITLE
fix: Only check the trailing slash if we are using the PDF generation

### DIFF
--- a/inline_scan.sh
+++ b/inline_scan.sh
@@ -192,7 +192,7 @@ get_and_validate_analyzer_options() {
         printf '\n\t%s\n\n' "ERROR - Directory: ${PDF_DIRECTORY} does not exist" >&2
         display_usage_analyzer >&2
         exit 1
-    elif [[ "${PDF_DIRECTORY: -1}" == '/' ]]; then
+    elif [[ "${R_flag:-}" ]] && [[ "${PDF_DIRECTORY: -1}" == '/' ]]; then
         printf '\n\t%s\n\n' "ERROR - must specify file path - ${PDF_DIRECTORY} without trailing slash" >&2
         display_usage_analyzer >&2
         exit 1


### PR DESCRIPTION
This PR fixes an error related to this commit: https://github.com/sysdiglabs/secure-inline-scan/commit/71141921063712e56ea3a1eeac318a9460dbbb12

We need to check only the trailing if the R_flag was specified, not on every case.