### PR TITLE
feat: Add a Makefile to automate building and publishing Docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+VERSION=$(shell cat version)
+
+build:
+	docker build --network=host -t sysdiglabs/secure_inline_scan:$(VERSION) .
+
+push:
+	docker push sysdiglabs/secure_inline_scan:$(VERSION)
+	docker tag sysdiglabs/secure_inline_scan:$(VERSION) sysdiglabs/secure_inline_scan:latest
+	docker push sysdiglabs/secure_inline_scan:latest


### PR DESCRIPTION
This PR adds  Makefile useful for bulding and pushing the image to DockerHub

In a future I would like to have this step automated in a CI/CD, but meanwhile just with a small Makefile will be enough.

I also don't like the secure_inline_scan using the underscore instead the dashes, but that change may be not backwards compatible.