### PR TITLE
Fix image name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM docker:dind
 MAINTAINER Sysdig
 
 RUN apk --no-cache add curl bash
-COPY inline_scan.sh /bin/inline_scan
+COPY inline_scan.sh /bin/inline_scan.sh
 
-ENTRYPOINT ["/bin/inline_scan"]
+ENTRYPOINT ["/bin/inline_scan.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,5 @@ MAINTAINER Sysdig
 
 RUN apk --no-cache add curl bash
 COPY inline_scan.sh /bin/inline_scan
+
+ENTRYPOINT ["/bin/inline_scan"]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION=$(shell cat version)
 IMAGE_NAME=sysdiglabs/secure-inline-scan
 
 build:
-	docker build --network=host -t $(IMAGE_NAME):$(VERSION) .
+	docker build -t $(IMAGE_NAME):$(VERSION) .
 
 push:
 	docker push $(IMAGE_NAME):$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 VERSION=$(shell cat version)
+IMAGE_NAME=sysdiglabs/secure-inline-scan
 
 build:
-	docker build --network=host -t sysdiglabs/secure_inline_scan:$(VERSION) .
+	docker build --network=host -t $(IMAGE_NAME):$(VERSION) .
 
 push:
-	docker push sysdiglabs/secure_inline_scan:$(VERSION)
-	docker tag sysdiglabs/secure_inline_scan:$(VERSION) sysdiglabs/secure_inline_scan:latest
-	docker push sysdiglabs/secure_inline_scan:latest
+	docker push $(IMAGE_NAME):$(VERSION)
+	docker tag $(IMAGE_NAME):$(VERSION) $(IMAGE_NAME):latest
+	docker push $(IMAGE_NAME):latest

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Sysdig Secure 3.2 - https://download.sysdig.com/stable/inline-scan-versioned/inl
 
 **Note**: For Airgapped environments, we suggest the following:
 * docker pull docker.io/anchore/inline-scan:v0.6.1
-* docker pull sysdiglabs/secure_inline_scan:latest (if using the inline scan container)
+* docker pull sysdiglabs/secure-inline-scan:latest (if using the inline scan container)
 * Open firewall settings to allow traffic to https://secure.sysdig.com/api/scanning
 
 ## Usage
@@ -72,8 +72,8 @@ On the host via the script
 
 Using docker
 
-    $ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock sysdiglabs/secure_inline_scan:latest /bin/inline_scan analyze -s <SYSDIG_REMOTE_URL> -k <API Token> [ OPTIONS ] <FULL_IMAGE_TAG>
-       
+    $ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock sysdiglabs/secure-inline-scan:latest analyze -s <SYSDIG_REMOTE_URL> -k <API Token> [ OPTIONS ] <FULL_IMAGE_TAG>
+
 ## Example
 
 #### Analyze the image and post the results to Sysdig Secure.


### PR DESCRIPTION
This is the unique image that is using underscores instead of dashes.

We are working on the blogposts and other integrations which are using this, but we are going to change that.