### PR TITLE
Fix for policy matching in SSPROD-2984

### DIFF
--- a/inline_scan.sh
+++ b/inline_scan.sh
@@ -284,7 +284,7 @@ start_analysis() {
         get_repo_digest_id
     fi
 
-    FULLTAG="${SCAN_IMAGES[0]}"
+    FULLTAG="localbuild/${SCAN_IMAGES[0]}"
 
     printf '%s\n\n' "Image id: ${SYSDIG_IMAGE_ID}"
     get_scan_result_code_by_id


### PR DESCRIPTION
This change fixes the policy mismatch described in SSPROD-2984, and also fixes the URL that is reported at the end of the script, which doesn't work as it is missing the localbuild/ prefix.

It is apparently working an tested in the Github Action https://github.com/sysdiglabs/scan-action/commits/update-script, but please review and check if this can cause any other issue.