### PR TITLE
fix: Use a fixed version as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:dind
+FROM docker:18-dind
 
 MAINTAINER Sysdig
 


### PR DESCRIPTION
Using a too recent image returns errors when running inline scanning on
K8s based integrations like Harbor one.