### PR TITLE
Adding loop to ensure that docker save tar is created

### DIFF
--- a/inline_scan.sh
+++ b/inline_scan.sh
@@ -535,6 +535,13 @@ save_and_copy_images() {
 
     docker save "${SCAN_IMAGES[0]}" -o "${save_file_path}"
 
+    while [[ ! -s "${save_file_path}" ]]; do
+        if [[ "${V_flag:-}" ]]; then
+            echo "waiting for docker save to finish"
+        fi
+        sleep 1
+    done
+
     if [[ -f "${save_file_path}" ]]; then
         chmod +r "${save_file_path}"
         printf '%s' "Successfully prepared image archive -- ${save_file_path}"

--- a/inline_scan.sh
+++ b/inline_scan.sh
@@ -535,6 +535,7 @@ save_and_copy_images() {
 
     docker save "${SCAN_IMAGES[0]}" -o "${save_file_path}"
 
+    echo "docker save is in progress..."
     while [[ ! -s "${save_file_path}" ]]; do
         if [[ "${V_flag:-}" ]]; then
             echo "waiting for docker save to finish"


### PR DESCRIPTION
This is to address the race condition observed in Mindbody where the tar file was not saved in time before the `docker start` was invoked.
Adding loop to ensure that docker save tar is created