### PR TITLE
Fix display TAG information

### DIFF
--- a/inline_scan.sh
+++ b/inline_scan.sh
@@ -421,7 +421,7 @@ get_repo_digest_id() {
 
     REPO=$(echo ${IMAGE_NAMES[0]} | rev |  cut -d / -f 2 | rev)
     BASE_IMAGE=$(echo ${IMAGE_NAMES[0]} | rev | cut -d / -f 1 | rev | cut -d : -f 1)
-    TAG=$(echo ${IMAGE_NAMES[0]} | rev | cut -d / -f 1 | rev | cut -d : -f 2)
+    TAG=$(echo ${IMAGE_NAMES[0]} | rev | cut -d / -f 1 | rev | cut -d : -s -f 2)
 
     if [[ -z "${TAG// }" ]]; then
         TAG='latest'


### PR DESCRIPTION
If tag is not specified, "latest" is used, but the image name is displayed instead, as `cut -d : -f 2` will return the full line if there is no ":" separator. Add -s option to return a blank line, so the *if* in line 426 sets "latest" as TAG.