### PR TITLE
change: use status endpoint to verify credentials. Fixes #62

### DIFF
--- a/inline_scan.sh
+++ b/inline_scan.sh
@@ -167,8 +167,8 @@ get_and_validate_analyzer_options() {
         printf '\n\t%s\n\n' "ERROR - must specify a valid sha256:<digestID>: ${SYSDIG_IMAGE_DIGEST}" >&2
         display_usage_analyzer >&2
         exit 1
-    elif ! curl -k -s --fail -H "Authorization: Bearer ${SYSDIG_API_TOKEN}" "${SYSDIG_ANCHORE_URL}/images" > /dev/null; then
-        printf '\n\t%s\n\n' "ERROR - invalid combination of Sysdig secure endpoint : token provided - ${SYSDIG_SCANNING_URL} : ${SYSDIG_API_TOKEN}" >&2
+    elif ! curl -k -s --fail -H "Authorization: Bearer ${SYSDIG_API_TOKEN}" "${SYSDIG_SCANNING_URL%%/}/anchore/status" > /dev/null; then
+        printf '\n\t%s\n\n' "ERROR - invalid combination of Sysdig secure endpoint" >&2
         display_usage_analyzer >&2
         exit 1
     elif [[ "${a_flag:-}" ]]; then


### PR DESCRIPTION
This PR fixes #62 by using status endpoint (much lighter) for verifying provided credentials.