### PR TITLE
Fix: remove newline char from status

### DIFF
--- a/inline_scan.sh
+++ b/inline_scan.sh
@@ -473,6 +473,7 @@ get_scan_result_with_retries() {
         get_scan_result_code
         if [[ "${GET_CALL_STATUS}" == 200 ]]; then
             status=$(curl -sk --header "Content-Type: application/json" -H "Authorization: Bearer ${SYSDIG_API_TOKEN}" "${SYSDIG_ANCHORE_URL}/images/${SYSDIG_IMAGE_DIGEST}/check?tag=${FULLTAG}&detail=${DETAIL}" | grep "status" | cut -d : -f 2 | awk -F\" '{ print $2 }')
+            status=$(echo ${status} | tr -d '\n')
             break
         fi
         echo -n "." && sleep 1

--- a/inline_scan.sh
+++ b/inline_scan.sh
@@ -473,7 +473,7 @@ get_scan_result_with_retries() {
         get_scan_result_code
         if [[ "${GET_CALL_STATUS}" == 200 ]]; then
             status=$(curl -sk --header "Content-Type: application/json" -H "Authorization: Bearer ${SYSDIG_API_TOKEN}" "${SYSDIG_ANCHORE_URL}/images/${SYSDIG_IMAGE_DIGEST}/check?tag=${FULLTAG}&detail=${DETAIL}" | grep "status" | cut -d : -f 2 | awk -F\" '{ print $2 }')
-            status=$(echo ${status} | tr -d '\n')
+            status=$(echo "${status}" | tr -d '\n')
             break
         fi
         echo -n "." && sleep 1


### PR DESCRIPTION
```
./inline_scan.sh  analyze  -s <> -k <> sysdiglabs/dummy-vuln-app
.....
...
+ [[ -n '' ]]
+ [[ pass
pass = \p\a\s\s ]]
+ printf '\nStatus is fail\n'
+ print_scan_result_summary_message
+ [[ ! -n true ]]
+ exit 1
+ cleanup
+ local ret=1
+ [[ 0 -ge 1 ]]
+ set +e
+ [[ -z '' ]]

Status is fail
+ DOCKER_ID=13374-inline-anchore-engine
+ for id in ${DOCKER_ID}
+ local -i timeout=0
+ docker ps -a
+ grep 13374-inli
+ [[ 0 -ge 12 ]]
+ unset DOCKER_ID
+ [[ 0 -ge 1 ]]
+ [[ -f /tmp/sysdig/sysdig_output.log ]]
+ exit 1
```

After fix,
```
using full image name: docker.io/sysdiglabs/dummy-vuln-app:latest
Image digest found on Sysdig Secure, skipping analysis.
Scan Report - 
[
 {
  "sha256:bc86e8ba5741ab71ce50f13fbf89a1f27dc4e1d3b0c3345cee8e3238bc30022b": {
   "docker.io/sysdiglabs/dummy-vuln-app:latest": [
    {
     "detail": {},
     "last_evaluation": "2020-09-08T21:33:46Z",
     "policyId": "default",
     "status": "pass"
    }
   ]
  }
 }
]
Status is pass

```
