### PR TITLE
Use a different base URL for Sysdig SaaS API

### DIFF
--- a/inline_scan.sh
+++ b/inline_scan.sh
@@ -24,7 +24,8 @@ DOCKERFILE="./Dockerfile"
 TIMEOUT=300
 TMP_PATH="/tmp/sysdig"
 # Analyzer option variable defaults
-SYSDIG_BASE_SCANNING_URL="https://api.sysdigcloud.com"
+SYSDIG_BASE_SCANNING_API_URL="https://api.sysdigcloud.com"
+SYSDIG_BASE_SCANNING_URL="https://secure.sysdig.com"
 SYSDIG_SCANNING_URL="http://localhost:9040/api/scanning"
 SYSDIG_ANCHORE_URL="http://localhost:9040/api/scanning/v1/anchore"
 SYSDIG_ANNOTATIONS="foo=bar"
@@ -120,7 +121,7 @@ get_and_validate_analyzer_options() {
     while getopts ':k:s:a:d:f:i:m:R:v:CPVho' option; do
         case "${option}" in
             k  ) k_flag=true; SYSDIG_API_TOKEN="${OPTARG}";;
-            s  ) s_flag=true; SYSDIG_BASE_SCANNING_URL="${OPTARG%%}";;
+            s  ) s_flag=true; SYSDIG_BASE_SCANNING_URL="${OPTARG%%}";SYSDIG_BASE_SCANNING_API_URL="${SYSDIG_BASE_SCANNING_URL}";;
             a  ) a_flag=true; SYSDIG_ANNOTATIONS="${OPTARG}";;
             f  ) f_flag=true; DOCKERFILE="${OPTARG}";;
             i  ) i_flag=true; SYSDIG_IMAGE_ID="${OPTARG}";;
@@ -139,7 +140,7 @@ get_and_validate_analyzer_options() {
     done
     shift "$((OPTIND - 1))"
 
-    SYSDIG_SCANNING_URL="${SYSDIG_BASE_SCANNING_URL}"/api/scanning/v1
+    SYSDIG_SCANNING_URL="${SYSDIG_BASE_SCANNING_API_URL}"/api/scanning/v1
     SYSDIG_ANCHORE_URL="${SYSDIG_SCANNING_URL}"/anchore
     # Check for invalid options
     if [[ ! $(which docker) ]]; then


### PR DESCRIPTION
The scanning results page and the API use different base URLs in Sysdig SaaS environment.
On-prem installations use the same base URL for API and scanning results page.   