### PR TITLE
[SSPROD-5119] fix api Url for onprem envs

### DIFF
--- a/inline_scan.sh
+++ b/inline_scan.sh
@@ -121,7 +121,12 @@ get_and_validate_analyzer_options() {
     while getopts ':k:s:a:d:f:i:m:R:v:CPVho' option; do
         case "${option}" in
             k  ) k_flag=true; SYSDIG_API_TOKEN="${OPTARG}";;
-            s  ) s_flag=true; SYSDIG_BASE_SCANNING_URL="${OPTARG%%}";SYSDIG_BASE_SCANNING_API_URL="${SYSDIG_BASE_SCANNING_URL}";;
+            s  ) s_flag=true; SYSDIG_BASE_SCANNING_URL="${OPTARG%%}";
+                 if [[ $SYSDIG_BASE_SCANNING_URL == *"/secure" ]]; then
+                   SYSDIG_BASE_SCANNING_API_URL="${SYSDIG_BASE_SCANNING_URL%'/secure'}"; 
+                 else 
+                   SYSDIG_BASE_SCANNING_API_URL="${SYSDIG_BASE_SCANNING_URL}";
+                 fi;;
             a  ) a_flag=true; SYSDIG_ANNOTATIONS="${OPTARG}";;
             f  ) f_flag=true; DOCKERFILE="${OPTARG}";;
             i  ) i_flag=true; SYSDIG_IMAGE_ID="${OPTARG}";;


### PR DESCRIPTION
See https://sysdig.atlassian.net/browse/SSPROD-5119

Using the suggested inline_scan command in "Get Started" (onboarding) in any onprem or IBM system, we're getting the following error:

```
#curl -s https://download.sysdig.com/stable/inline_scan.sh | bash -s -- analyze -s https://us-south.monitoring.test.cloud.ibm.com/secure -k cc9f2a4f-26de-4fd1-b863-2db77264e26c -P docker.io/nginx:latest 

        ERROR - invalid combination of Sysdig secure endpoint
```

that's because the expected url is an api url and not the result url. In any case, if `/secure` is removed, the script can go on, but then the result url is wrong, e.g:

```
Status is pass
View the full result @ https://us-south.monitoring.test.cloud.ibm.com/#/scanning/scan-results/docker.io%2Fnginx%3Alatest/sha256:c628b67d21744fce822d22fdcc0389f6bd763daac23a6b77147d0712ea7102d0/summaries
```

so a possible solution is to mange properly the onprem/IBM case, in which the Secure url ends with "/secure"