### PR TITLE
docs: Examples for Tekton and bash script docker scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For version 1.x.y documentation head over [here](./v1.md)
 ### Locally built image (local registry)
 
 ```
-docker run --rm
+docker run --rm \
     -v /var/run/docker.sock:/var/run/docker.sock \
     sysdiglabs/secure-inline-scan:2 \
     --sysdig-url <omitted> \
@@ -42,7 +42,7 @@ docker run --rm
 Assuming it's avaiable the image tarball at `image.tar`.
 
 ```
-docker run --rm
+docker run --rm \
     -v ${PWD}/image.tar:/tmp/image.tar \
     sysdiglabs/secure-inline-scan:2 \
     --sysdig-url <omitted> \

--- a/examples/tekton/README.md
+++ b/examples/tekton/README.md
@@ -1,0 +1,211 @@
+# Tekton inline scanning with Sysdig
+
+This repository contains instructions and examples of how to use Sysdig inline scanning to detect vulnerabilities and misconfiguration in a Tekton CI/CD pipeline, using the **alpha** and **beta** Tekton API.
+
+They have been tested and can be used for **vanilla Kubernetes** as well as on **OpenShift**, as Sysdig inline scanning doesn't require a privileged container.
+
+For more information about Sysdig, visit [https://sysdig.com](https://sysdig.com).
+
+## Inline Image Scanning
+
+Sysdig inline image sanning can be used in Tekton, without requiring a docker-in-docker setup, mounting the Docker socket or privileged access.
+
+You have to define a scanning step after building an image in a Tekton task, so it then scans a local folder with the image contents in OCI format, without pushing it to a registry or sending the image contents to Sysdig backend. This is a brief code extract for how to do it (for Tekton v1beta1 API):
+
+```yaml
+  - name: scan
+    image: sysdiglabs/secure-inline-scan:2
+    args:
+      - --storage-type
+      - oci-dir
+      - --storage-path
+      - /workspace/oci
+      - -s
+      - https://secure.sysdig.com
+      - $(outputs.resources.builtImage.url)
+    env:
+      - name: SYSDIG_API_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: sysdig-secrets
+            key: sysdig-secure-api-key
+```
+
+You'll need to add a secret for your Sysdig Secure API token, and reference it in the service account definition that executes the pipeline, as you can see in the [full pipeline example for beta Tekton API](./beta/tekton-inline-scan-localbuild-beta.yaml).
+
+## Build-scan-push Tekton Task
+
+The example pipeline describen in the [official Tekton tutorial](https://github.com/tektoncd/pipeline/blob/master/docs/tutorial.md) uses `kaniko` to build and push the image in a single step. 
+
+To have a task that builds the image, scans it locally, and only pushes it to the registry if it is in compliance with scanning policies, we have to tell `kaniko` in the first step to not push the image, and add a last additional step to push it using `skopeo` (as `kaniko` can't push an image without rebuilding it, which would waste resources).
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: build-docker-image-from-git-source
+spec:
+  params:
+    - name: pathToDockerFile
+      type: string
+      description: The path to the dockerfile to build
+      default: $(resources.inputs.docker-source.path)/Dockerfile
+    - name: pathToContext
+      type: string
+      description: |
+        The build context used by Kaniko
+        (https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts)
+      default: $(resources.inputs.docker-source.path)
+  resources:
+    inputs:
+      - name: docker-source
+        type: git
+    outputs:
+      - name: builtImage
+        type: image
+  steps:
+    - name: build
+      image: gcr.io/kaniko-project/executor:v0.16.0
+      command:
+        - /kaniko/executor
+      args:
+        - --dockerfile=$(params.pathToDockerFile)
+        - --destination=$(resources.outputs.builtImage.url)
+        - --context=$(params.pathToContext)
+        - --oci-layout-path=/workspace/oci
+        - --no-push
+
+    - name: scan
+      image: sysdiglabs/secure-inline-scan:2
+      args:
+        - --storage-type
+        - oci-dir
+        - --storage-path
+        - /workspace/oci
+        - -s
+        - https://secure.sysdig.com
+        - $(outputs.resources.builtImage.url)
+      env:
+        - name: SYSDIG_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: sysdig-secrets
+              key: sysdig-secure-api-key
+
+    - name: push
+      image: quay.io/skopeo/stable:v1.1.1
+      command:
+        - /usr/bin/skopeo
+      args:
+        - --insecure-policy
+        - --dest-authfile
+        - /tekton/home/.docker/config.json
+        - copy
+        - oci:/workspace/oci/
+        - docker://$(outputs.resources.builtImage.url)
+
+```
+
+## Full pipeline examples with inline scanning for alpha and beta Tekton API
+
+You can find full pipelines examples for both **alpha** and **beta** Tekton API in the following files of this repo:
+
+* [pipeline-example-alpha.yaml](./alpha/tekton-inline-scan-localbuild-alpha.yaml).
+* [pipeline-example-beta.yaml](./beta/tekton-inline-scan-locallbuild-beta.yaml).
+
+They are quite similar, but each derives from the tutorial examples given for those versions of the API. Main difference is how registry credential secrets were recommended to be handled, but the task for build-scan-push is almost identical.
+
+### Tekton beta API example
+
+Follow these steps to test the Tekton beta API example from this repo.
+
+```console
+oc new-project tekton-pipelines
+oc adm policy add-scc-to-user anyuid -z tekton-pipelines-controller
+```
+
+* Modify `beta/sample-registry-secrets.sh` script with your registry credentials.
+* Modify `beta/sample-sysdig-secrets.yaml` and paste your Sysdig Secure API key.
+* Modify `beta/tekton-inlin-scan-beta.yaml` file, at line 32 substitude `index.docker.io/your_user/leeroy-web` for the image tag you want to use on your registry account.
+
+If you use OpenShift instead of Kubernetes, execute these commands to create a project and specify anyuid to the Tekton pipeline controller so it can run containers with root user (required by Tekton).
+
+```bash
+oc new-project tekton-pipelines
+oc ad
+
+* Execute these commands:
+
+```bash
+# Deploy Tekton v0.16.3
+kubectl apply -f https://github.com/tektoncd/pipeline/releases/download/v0.16.3/release.notags.yaml
+
+# Deploy Dashboard v0.9.0
+kubectl apply -f https://github.com/tektoncd/dashboard/releases/download/v0.9.0/tekton-dashboard-release.yaml
+
+# Check that Tekton and dashboard pod status are ready
+kubectl get pods -n tekton-pipelines
+
+# Prepare example
+cd beta
+./sample-registry-secrets-beta.sh
+kubectl apply -f sample-sysdig-secrets.yaml -n tekton-pipelines
+./service-role.sh
+
+# Execute example
+kubectl create -f tekton-inline-scan-localbuild-beta.yaml -n tekton-pipelines
+
+# Open proxy connection to dashboard
+kubectl port-forward svc/tekton-dashboard -n tekton-pipelines 9097:9097
+
+# Browse dashboard web page at http://[::1]:9097
+```
+
+### Tekton alpha API example
+
+Follow these steps to test the Tekton beta API example from this repo.
+
+* Modify `alpha/sample-registry-secrets-beta.yaml` file with your registry credentials.
+* Modify `alpha/sample-sysdig-secrets.yaml` and paste your Sysdig Secure API key.
+* Modify `alpha/tekton-inlin-scan-alpha.yaml` file, at line 153 substitude `docker.io/username/leeroy-web2a` for the image tag you want to use on your registry account.
+
+If you use OpenShift instead of Kubernetes, execute these commands to create a project and specify anyuid to the Tekton pipeline controller so it can run containers with root user (required by Tekton).
+
+```bash
+oc new-project tekton-pipelines
+oc adm policy add-scc-to-user anyuid -z tekton-pipelines-controller
+```
+
+* Execute these commands:
+
+```bash
+# Deploy Tekton v0.10.2
+kubectl apply -f https://github.com/tektoncd/pipeline/releases/download/v0.10.2/release.notags.yaml
+
+# Deploy Dashboard v0.5.1
+kubectl apply -f https://github.com/tektoncd/dashboard/releases/download/v0.5.1/tekton-dashboard-release.yaml
+
+# Check that Tekton and dashboard pod status are ready
+kubectl get pods -n tekton-pipelines
+
+# Prepare example
+cd alpha
+kubectl apply -f sample-registry-secrets.yaml
+kubectl apply -f sample-sysdig-secrets.yaml
+
+# Execute example
+kubectl apply -f tekton-inline-scan-localbuild-localbuild-alpha.yaml
+
+# Open proxy connection to dashboard
+kubectl port-forward svc/tekton-dashboard -n tekton-pipelines 9097:9097
+
+# Browse dashboard web page at http://[::1]:9097
+```
+
+## References
+
+* [Sysdig Inline Scan](https://github.com/sysdiglabs/secure-inline-scan), _code repository_ and _direct project documentation_. This is the main source of truth for Sysdig inline scanning.
+* [Inline Scanning](https://docs.sysdig.com/en/integrate-with-ci-cd-tools.html#UUID-8945ddee-8c45-58b4-7d85-e06c4235d03c_UUID-5d107c7b-457e-3862-51b5-01bdd9699105), _Sysdig Documentation Hub_.
+* [Securing Tekton pipelines in OpenShift with Sysdig](https://sysdig.com/blog/securing-tekton-pipelines-openshift/), _blogpost_.
+  ⚠**Deprecated information**.
+

--- a/examples/tekton/alpha/sample-registry-secrets.yaml
+++ b/examples/tekton/alpha/sample-registry-secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: docker-auth-for-tekton
+  annotations:
+    tekton.dev/docker-0: https://index.docker.io
+    tekton.dev/docker-1: https://gcr.io
+type: kubernetes.io/basic-auth
+stringData:
+  username: <username>
+  password: <password>

--- a/examples/tekton/alpha/sample-sysdig-secrets.yaml
+++ b/examples/tekton/alpha/sample-sysdig-secrets.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sysdig-secrets
+data:
+  sysdig-secure-api-key: <your_apy_key>
+

--- a/examples/tekton/alpha/tekton-inline-scan-localbuild-alpha.yaml
+++ b/examples/tekton/alpha/tekton-inline-scan-localbuild-alpha.yaml
@@ -1,0 +1,192 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-bot
+secrets:
+  - name: docker-auth-for-tekton
+  - name: sysdig-secrets
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: build-bot-tekton-pipelines-admin
+  namespace: tekton-pipelines
+subjects:
+- kind: User
+  name: build-bot
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: tekton-pipelines-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: build-bot-deploy-role
+  namespace: tekton-pipelines
+rules:
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments"]
+  verbs: ["get", "create", "update", "patch"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "create", "update", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: build-bot-deploy-binding
+  namespace: tekton-pipelines
+subjects:
+- kind: ServiceAccount
+  name: build-bot
+  namespace: tekton-pipelines
+roleRef:
+  kind: Role
+  name: build-bot-deploy-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: build-scan-push
+spec:
+  inputs:
+    resources:
+      - name: repository
+        type: git
+    params:
+      - name: pathToDockerFile
+        description: The path to the dockerfile to build
+        default: /workspace/repository/Dockerfile
+      - name: pathToContext
+        description: The build context used by Kaniko (https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts)
+        default: /workspace/repository
+  outputs:
+    resources:
+      - name: builtImage
+        type: image
+  steps:
+
+    - name: build
+      image: gcr.io/kaniko-project/executor:latest
+      # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
+      env:
+        - name: "DOCKER_CONFIG"
+          value: "/tekton/home/.docker/"      
+      command:
+        - /kaniko/executor
+      args:
+        - --dockerfile=$(inputs.params.pathToDockerFile)
+        - --destination=$(outputs.resources.builtImage.url)
+        - --context=$(inputs.params.pathToContext)
+        - --no-push
+        - --oci-layout-path=/workspace/oci
+
+    - name: scan
+      image: sysdiglabs/secure-inline-scan:2
+      args:
+        - --storage-type
+        - oci-dir
+        - --storage-path
+        - /workspace/oci
+        - -s
+        - https://secure.sysdig.com
+        - $(outputs.resources.builtImage.url)
+      env:
+        - name: SYSDIG_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: sysdig-secrets
+              key: sysdig-secure-api-key
+
+    - name: push
+      image: quay.io/skopeo/stable
+      command:
+        - /usr/bin/skopeo
+      args:
+        - --insecure-policy      
+        - --dest-authfile
+        - /tekton/home/.docker/config.json
+        - copy
+        - oci:/workspace/oci/
+        - docker://$(outputs.resources.builtImage.url)
+
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: demo-pipeline
+spec:
+  resources:
+  - name: source-repo
+    type: git
+  - name: web-image
+    type: image
+
+  tasks:
+
+  - name: build-skaffold-web
+    taskRef:
+      name: build-scan-push
+    params:
+    - name: pathToDockerFile
+      value: Dockerfile
+    - name: pathToContext
+      value: /workspace/repository/examples/microservices/leeroy-web
+    resources:
+      inputs:
+      - name: repository
+        resource: source-repo
+      outputs:
+      - name: builtImage
+        resource: web-image
+
+
+
+# =================================================
+
+
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: skaffold-image-leeroy-web-pipelinerun
+spec:
+  type: image
+  params:
+  - name: url
+    value: docker.io/username/leeroy-web2a
+
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: skaffold-git-pipelinerun
+spec:
+  type: git
+  params:
+  - name: revision
+    value: v0.32.0
+  - name: url
+    value: https://github.com/GoogleContainerTools/skaffold
+    
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: demo-pipeline-run-1
+spec:
+  pipelineRef:
+    name: demo-pipeline
+  serviceAccountName: build-bot
+  resources:
+  - name: source-repo
+    resourceRef:
+      name: skaffold-git-pipelinerun
+  - name: web-image
+    resourceRef:
+      name: skaffold-image-leeroy-web-pipelinerun
+

--- a/examples/tekton/alpha/tekton-inline-scan-registry-alpha.yaml
+++ b/examples/tekton/alpha/tekton-inline-scan-registry-alpha.yaml
@@ -1,0 +1,169 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-bot
+secrets:
+  - name: docker-auth-for-tekton
+  - name: sysdig-secrets
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: build-bot-tekton-pipelines-admin
+  namespace: tekton-pipelines
+subjects:
+  - kind: User
+    name: build-bot
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: tekton-pipelines-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: build-bot-deploy-role
+  namespace: tekton-pipelines
+rules:
+  - apiGroups: ["extensions", "apps"]
+    resources: ["deployments"]
+    verbs: ["get", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "create", "update", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: build-bot-deploy-binding
+  namespace: tekton-pipelines
+subjects:
+  - kind: ServiceAccount
+    name: build-bot
+    namespace: tekton-pipelines
+roleRef:
+  kind: Role
+  name: build-bot-deploy-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: build-scan-push
+spec:
+  inputs:
+    resources:
+      - name: repository
+        type: git
+    params:
+      - name: pathToDockerFile
+        description: The path to the dockerfile to build
+        default: /workspace/repository/Dockerfile
+      - name: pathToContext
+        description: The build context used by Kaniko (https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts)
+        default: /workspace/repository
+  outputs:
+    resources:
+      - name: builtImage
+        type: image
+  steps:
+    - name: build-and-push
+      image: gcr.io/kaniko-project/executor:latest
+      command:
+        - /kaniko/executor
+      args:
+        - --dockerfile=$(inputs.params.pathToDockerFile)
+        - --destination=$(outputs.resources.builtImage.url)
+        - --context=$(inputs.params.pathToContext)
+
+    - name: scan
+      image: sysdiglabs/secure-inline-scan:2
+      args:
+        - --registry-auth-file
+        - /tekton/home/.docker/config.json
+        - -s
+        - https://secure.sysdig.com
+        - $(outputs.resources.builtImage.url)
+      securityContext:
+        runAsUser: 0
+      env:
+        - name: SYSDIG_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: sysdig-secrets
+              key: sysdig-secure-api-key
+
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: demo-pipeline
+spec:
+  resources:
+    - name: source-repo
+      type: git
+    - name: web-image
+      type: image
+
+  tasks:
+
+    - name: build-skaffold-web
+      taskRef:
+        name: build-scan-push
+      params:
+        - name: pathToDockerFile
+          value: Dockerfile
+        - name: pathToContext
+          value: /workspace/repository/examples/microservices/leeroy-web
+      resources:
+        inputs:
+          - name: repository
+            resource: source-repo
+        outputs:
+          - name: builtImage
+            resource: web-image
+
+# =================================================
+
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: skaffold-image-leeroy-web-pipelinerun
+spec:
+  type: image
+  params:
+    - name: url
+      value: docker.io/vicenteherrera/leeroy-web
+
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: skaffold-git-pipelinerun
+spec:
+  type: git
+  params:
+    - name: revision
+      value: v0.32.0
+    - name: url
+      value: https://github.com/GoogleContainerTools/skaffold
+
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: demo-pipeline-run-1
+spec:
+  pipelineRef:
+    name: demo-pipeline
+  serviceAccountName: build-bot
+  resources:
+    - name: source-repo
+      resourceRef:
+        name: skaffold-git-pipelinerun
+    - name: web-image
+      resourceRef:
+        name: skaffold-image-leeroy-web-pipelinerun

--- a/examples/tekton/beta/sample-registry-secrets-beta.sh
+++ b/examples/tekton/beta/sample-registry-secrets-beta.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+kubectl create secret docker-registry regcred \
+                    --docker-server=index.docker.io \
+                    --docker-username=<username> \
+                    --docker-password=<password> \
+                    --docker-email=<email> \
+                     -n tekton-pipelines

--- a/examples/tekton/beta/sample-sysdig-secrets.yaml
+++ b/examples/tekton/beta/sample-sysdig-secrets.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sysdig-secrets
+data:
+  sysdig-secure-api-key: <your_apy_key>
+

--- a/examples/tekton/beta/service-role.sh
+++ b/examples/tekton/beta/service-role.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+kubectl create clusterrole tutorial-role \
+               --verb=* \
+               --resource=deployments,deployments.apps
+
+kubectl create clusterrolebinding tutorial-binding \
+             --clusterrole=tutorial-role \
+             --serviceaccount=default:tutorial-service

--- a/examples/tekton/beta/tekton-inline-scan-localbuild-beta.yaml
+++ b/examples/tekton/beta/tekton-inline-scan-localbuild-beta.yaml
@@ -1,0 +1,196 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tutorial-service
+secrets:
+  - name: regcred
+  - name: sysdig-secrets
+
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: skaffold-git
+spec:
+  type: git
+  params:
+    - name: revision
+      value: master
+    - name: url
+      value: https://github.com/GoogleContainerTools/skaffold
+
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: skaffold-image-leeroy-web
+spec:
+  type: image
+  params:
+    - name: url
+      value: index.docker.io/vicenteherrera/leeroy-web
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: build-docker-image-from-git-source
+spec:
+  params:
+    - name: pathToDockerFile
+      type: string
+      description: The path to the dockerfile to build
+      default: $(resources.inputs.docker-source.path)/Dockerfile
+    - name: pathToContext
+      type: string
+      description: |
+        The build context used by Kaniko
+        (https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts)
+      default: $(resources.inputs.docker-source.path)
+  resources:
+    inputs:
+      - name: docker-source
+        type: git
+    outputs:
+      - name: builtImage
+        type: image
+  steps:
+    - name: build
+      image: gcr.io/kaniko-project/executor:v0.16.0
+      command:
+        - /kaniko/executor
+      args:
+        - --dockerfile=$(params.pathToDockerFile)
+        - --destination=$(resources.outputs.builtImage.url)
+        - --context=$(params.pathToContext)
+        - --oci-layout-path=/workspace/oci
+        - --no-push
+
+    - name: scan
+      image: sysdiglabs/secure-inline-scan:2
+      args:
+        - --storage-type
+        - oci-dir
+        - --storage-path
+        - /workspace/oci
+        - -s
+        - https://secure.sysdig.com
+        - $(outputs.resources.builtImage.url)
+      env:
+        - name: SYSDIG_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: sysdig-secrets
+              key: sysdig-secure-api-key
+
+    - name: push
+      image: quay.io/skopeo/stable:v1.1.1
+      command:
+        - /usr/bin/skopeo
+      args:
+        - --insecure-policy
+        - --dest-authfile
+        - /tekton/home/.docker/config.json
+        - copy
+        - oci:/workspace/oci/
+        - docker://$(outputs.resources.builtImage.url)
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: deploy-using-kubectl
+spec:
+  params:
+    - name: path
+      type: string
+      description: Path to the manifest to apply
+    - name: yamlPathToImage
+      type: string
+      description: |
+        The path to the image to replace in the yaml manifest (arg to yq)
+  resources:
+    inputs:
+      - name: source
+        type: git
+      - name: image
+        type: image
+  steps:
+    - name: replace-image
+      image: mikefarah/yq
+      command: ["yq"]
+      args:
+        - "w"
+        - "-i"
+        - "$(params.path)"
+        - "$(params.yamlPathToImage)"
+        - "$(resources.inputs.image.url)"
+    - name: run-kubectl
+      image: lachlanevenson/k8s-kubectl
+      command: ["kubectl"]
+      args:
+        - "apply"
+        - "-f"
+        - "$(params.path)"
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: tutorial-pipeline
+spec:
+  resources:
+    - name: source-repo
+      type: git
+    - name: web-image
+      type: image
+  tasks:
+    - name: build-skaffold-web
+      taskRef:
+        name: build-docker-image-from-git-source
+      params:
+        - name: pathToDockerFile
+          value: Dockerfile
+        - name: pathToContext
+          value: /workspace/docker-source/examples/microservices/leeroy-web #configure: may change according to your source
+      resources:
+        inputs:
+          - name: docker-source
+            resource: source-repo
+        outputs:
+          - name: builtImage
+            resource: web-image
+    - name: deploy-web
+      taskRef:
+        name: deploy-using-kubectl
+      resources:
+        inputs:
+          - name: source
+            resource: source-repo
+          - name: image
+            resource: web-image
+            from:
+              - build-skaffold-web
+      params:
+        - name: path
+          value: /workspace/source/examples/microservices/leeroy-web/kubernetes/deployment.yaml #configure: may change according to your source
+        - name: yamlPathToImage
+          value: "spec.template.spec.containers[0].image"
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: tutorial-pipeline-run-1
+spec:
+  serviceAccountName: tutorial-service
+  pipelineRef:
+    name: tutorial-pipeline
+  resources:
+    - name: source-repo
+      resourceRef:
+        name: skaffold-git
+    - name: web-image
+      resourceRef:
+        name: skaffold-image-leeroy-web

--- a/examples/tekton/beta/tekton-inline-scan-localbuild-beta.yaml
+++ b/examples/tekton/beta/tekton-inline-scan-localbuild-beta.yaml
@@ -29,7 +29,7 @@ spec:
   type: image
   params:
     - name: url
-      value: index.docker.io/vicenteherrera/leeroy-web
+      value: index.docker.io/username/leeroy-web
 
 ---
 apiVersion: tekton.dev/v1beta1

--- a/examples/tekton/beta/tekton-inline-scan-registry-beta.yaml
+++ b/examples/tekton/beta/tekton-inline-scan-registry-beta.yaml
@@ -1,0 +1,184 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tutorial-service
+secrets:
+  - name: regcred
+  - name: sysdig-secrets
+
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: skaffold-git
+spec:
+  type: git
+  params:
+    - name: revision
+      value: master
+    - name: url
+      value: https://github.com/GoogleContainerTools/skaffold
+
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: skaffold-image-leeroy-web
+spec:
+  type: image
+  params:
+    - name: url
+      value: index.docker.io/vicenteherrera/leeroy-web
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: build-docker-image-from-git-source
+spec:
+  params:
+    - name: pathToDockerFile
+      type: string
+      description: The path to the dockerfile to build
+      default: $(resources.inputs.docker-source.path)/Dockerfile
+    - name: pathToContext
+      type: string
+      description: |
+        The build context used by Kaniko
+        (https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts)
+      default: $(resources.inputs.docker-source.path)
+  resources:
+    inputs:
+      - name: docker-source
+        type: git
+    outputs:
+      - name: builtImage
+        type: image
+  steps:
+    - name: build-and-push
+      image: gcr.io/kaniko-project/executor:v0.16.0
+      # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
+      env:
+        - name: "DOCKER_CONFIG"
+          value: "/tekton/home/.docker/"
+      command:
+        - /kaniko/executor
+      args:
+        - --dockerfile=$(params.pathToDockerFile)
+        - --destination=$(resources.outputs.builtImage.url)
+        - --context=$(params.pathToContext)
+
+    - name: scan
+      image: sysdiglabs/secure-inline-scan:2
+      args:
+        - --registry-auth-file
+        - /tekton/creds/.docker/config.json
+        - -s
+        - https://secure.sysdig.com
+        - $(resources.outputs.builtImage.url)
+      env:
+        - name: SYSDIG_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: sysdig-secrets
+              key: sysdig-secure-api-key
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: deploy-using-kubectl
+spec:
+  params:
+    - name: path
+      type: string
+      description: Path to the manifest to apply
+    - name: yamlPathToImage
+      type: string
+      description: |
+        The path to the image to replace in the yaml manifest (arg to yq)
+  resources:
+    inputs:
+      - name: source
+        type: git
+      - name: image
+        type: image
+  steps:
+    - name: replace-image
+      image: mikefarah/yq
+      command: ["yq"]
+      args:
+        - "w"
+        - "-i"
+        - "$(params.path)"
+        - "$(params.yamlPathToImage)"
+        - "$(resources.inputs.image.url)"
+    - name: run-kubectl
+      image: lachlanevenson/k8s-kubectl
+      command: ["kubectl"]
+      args:
+        - "apply"
+        - "-f"
+        - "$(params.path)"
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: tutorial-pipeline
+spec:
+  resources:
+    - name: source-repo
+      type: git
+    - name: web-image
+      type: image
+  tasks:
+    - name: build-skaffold-web
+      taskRef:
+        name: build-docker-image-from-git-source
+      params:
+        - name: pathToDockerFile
+          value: Dockerfile
+        - name: pathToContext
+          value: /workspace/docker-source/examples/microservices/leeroy-web #configure: may change according to your source
+      resources:
+        inputs:
+          - name: docker-source
+            resource: source-repo
+        outputs:
+          - name: builtImage
+            resource: web-image
+    - name: deploy-web
+      taskRef:
+        name: deploy-using-kubectl
+      resources:
+        inputs:
+          - name: source
+            resource: source-repo
+          - name: image
+            resource: web-image
+            from:
+              - build-skaffold-web
+      params:
+        - name: path
+          value: /workspace/source/examples/microservices/leeroy-web/kubernetes/deployment.yaml #configure: may change according to your source
+        - name: yamlPathToImage
+          value: "spec.template.spec.containers[0].image"
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: tutorial-pipeline-run-1
+spec:
+  serviceAccountName: tutorial-service
+  pipelineRef:
+    name: tutorial-pipeline
+  resources:
+    - name: source-repo
+      resourceRef:
+        name: skaffold-git
+    - name: web-image
+      resourceRef:
+        name: skaffold-image-leeroy-web

--- a/examples/tekton/beta/tekton-inline-scan-registry-beta.yaml
+++ b/examples/tekton/beta/tekton-inline-scan-registry-beta.yaml
@@ -29,7 +29,7 @@ spec:
   type: image
   params:
     - name: url
-      value: index.docker.io/vicenteherrera/leeroy-web
+      value: index.docker.io/username/leeroy-web
 
 ---
 apiVersion: tekton.dev/v1beta1

--- a/examples/unprivileged-docker/localbuild_scan.sh
+++ b/examples/unprivileged-docker/localbuild_scan.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# v2: Updated to use sysdiglabs/secure-inline-scan:2
+
+# This is an example pipeline execution as a Bash script of how to
+# execute an inline scan with Sysdig without requiring priviledges.
+
+# The image is locally built, scanned without uploading its contents
+# to Sysdig backend, and if it passes the Scan policies, then it's
+# pushed to the registry. If it doesn't, nothing is pushed.
+
+# It employs Kaniko for build and Skopeo to push without requiring
+# privileged containers, root user or access to Docker socket.
+
+# You can adapt this script steps to the environment or CI/CD engine 
+# based on containers of your choice.
+
+set -euf
+
+KEYS=${$KEYS:-"./"}
+DOCKER_USER=$(cat $KEYS/DOCKER_USER)
+DOCKER_PASS=$(cat $KEYS/DOCKER_PASS)
+SYSDIG_SECURE_API_TOKEN=$(cat $KEYS/SYSDIG_SECURE_API_TOKEN)
+
+IMAGE=docker.io/vicenteherrera/leeroy-web-my
+REPO=https://github.com/GoogleContainerTools/skaffold
+DOCKERFILE=examples/microservices/leeroy-web/Dockerfile
+CONTEXT=examples/microservices/leeroy-web/
+
+function clone {
+    echo
+    echo "> Clone"
+    rm -rf repo
+    git clone $REPO repo
+}
+
+function build {
+    echo
+    echo "> Build"
+    docker run -v $PWD:/workspace \
+        gcr.io/kaniko-project/executor:latest \
+        --dockerfile=/workspace/repo/$DOCKERFILE \
+        --context=/workspace/repo/$CONTEXT \
+        --destination=$IMAGE \
+        --no-push \
+        --oci-layout-path=/workspace/oci \
+        --tarPath=/workspace/image.tar
+}
+
+function scan {
+
+    echo
+    echo "> Scan"
+
+    docker run -v $PWD:/workspace sysdiglabs/secure-inline-scan:2 \
+        -s https://secure.sysdig.com \
+        --storage-type oci-dir \
+        --storage-path /workspace/oci \
+        -k $SYSDIG_SECURE_API_TOKEN \
+        $IMAGE
+
+}
+
+function push {
+    echo
+    echo "> Push"
+
+    docker run \
+        -v $PWD:/workspace \
+        quay.io/skopeo/stable \
+        --dest-creds $DOCKER_USER:$DOCKER_PASS \
+        --insecure-policy \
+        copy \
+        oci:/workspace/oci/ \
+        docker://$IMAGE
+
+    # alternative: --dest-authfile /home/.docker/config.json
+}
+
+
+# PIPELINE
+
+clone
+build
+scan
+push

--- a/examples/unprivileged-docker/registry_scan.sh
+++ b/examples/unprivileged-docker/registry_scan.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Uses sysdiglabs/secure-inline-scan:2
+
+# This is an example script that scans from a private registry
+# with Sysdig without requiring priviledges.
+
+# It creates a temporary docker-config.json auth file for dockerhub registry, 
+# but can be replaced to use any other registry using Docker credentials.
+
+set -euf
+
+KEYS=${KEYS:-"./"}
+DOCKER_USER=$(cat $KEYS/DOCKER_USER)
+DOCKER_PASS=$(cat $KEYS/DOCKER_PASS)
+SYSDIG_SECURE_API_TOKEN=$(cat $KEYS/SYSDIG_SECURE_API_TOKEN)
+
+DOCKER_AUTH=$(echo -n "$DOCKER_USER:$DOCKER_PASS" | base64)
+IMAGE=docker.io/vicenteherrera/leeroy-web-my
+REPO=https://github.com/GoogleContainerTools/skaffold
+DOCKERFILE=examples/microservices/leeroy-web/Dockerfile
+CONTEXT=examples/microservices/leeroy-web/
+
+
+function docker_auth_create {
+
+    echo
+    echo "> Create docker-config.json"
+
+cat <<EOF > "./docker-config.json"
+    {
+        "auths":{        
+            "https://index.docker.io":{
+                "username":"${DOCKER_USER}",
+                "password":"${DOCKER_PASS}",
+                "auth":"${DOCKER_AUTH}",
+                "email":"not@val.id"
+            }
+        }
+    }
+EOF
+
+
+}
+
+function scan {
+
+    echo
+    echo "> Scan"
+
+    docker run \
+        -v $PWD:/workspace \
+        sysdiglabs/secure-inline-scan:2 \
+        --registry-auth-file /workspace/docker-config.json \
+        -k $SYSDIG_SECURE_API_TOKEN \
+        -s https://secure.sysdig.com \
+        $IMAGE
+
+}
+
+
+# PIPELINE
+
+docker_auth_create
+scan
+
+trap "rm -f docker-config.json" EXIT

--- a/files/sysdig-inline-scan.sh
+++ b/files/sysdig-inline-scan.sh
@@ -83,7 +83,7 @@ Sysdig Inline Analyzer -- USAGE
                 Alternatively, set environment variable SYSDIG_API_TOKEN
                 Alias: --sysdig-token
     -s <URL>    [optional] Sysdig Secure URL (ex: -s 'https://secure-sysdig.svc.cluster.local').
-                If not specified, it will default to Sysdig Secure SaaS URL (https://secure.sysdig.com/).
+                If not specified, it will default to Sysdig Secure SaaS URL (https://secure.sysdig.com).
                 Alias: --sysdig-url
     --sysdig-skip-tls
                 [optional] skip tls verification when calling secure endpoints

--- a/files/sysdig-inline-scan.sh
+++ b/files/sysdig-inline-scan.sh
@@ -144,6 +144,10 @@ Sysdig Inline Analyzer -- USAGE
         oci-dir         Image is provided as a OCI image, untared.
                         The directory must be mounted inside the container and path set with --storage-path
 
+    --storage-path <PATH>   Specifies the path to the source of the image to scan, that has to be 
+                            mounted inside the container, it is required if --storage-type is set to 
+                            docker-archive, oci-archive or oci-dir
+
     == EXIT CODES ==
 
     0   Scan result "pass"

--- a/inline_scan.sh
+++ b/inline_scan.sh
@@ -80,7 +80,7 @@ Sysdig Inline Analyzer --
 
       -k <TEXT>  [required] API token for Sysdig Scanning auth (ex: -k 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx')
       -s <TEXT>  [optional] Sysdig Secure URL (ex: -s 'https://secure-sysdig.svc.cluster.local').
-                 If not specified, it will default to Sysdig Secure SaaS URL (https://secure.sysdig.com/).
+                 If not specified, it will default to Sysdig Secure SaaS URL (https://secure.sysdig.com).
       -a <TEXT>  [optional] Add annotations (ex: -a 'key=value,key=value')
       -f <PATH>  [optional] Path to Dockerfile (ex: -f ./Dockerfile)
       -i <TEXT>  [optional] Specify image ID used within Sysdig (ex: -i '<64 hex characters>')

--- a/inline_scan_docker.sh
+++ b/inline_scan_docker.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker run --rm -ti -v /var/run/docker.sock:/var/run/docker.sock sysdiglabs/secure-inline-scan:2 "$@"
+docker run --rm -ti sysdiglabs/secure-inline-scan:2 "$@"


### PR DESCRIPTION
- Added Tekton beta & alpha examples
- Added examples for bash script using unprivileged docker
- Removed trailing slash for Sysdig Secure URL example, as it requires not to have one
- Removed hardcoding mounting Docker socket as many scan scenarios don't require it
