### PR TITLE
Improve curl error handling and fix Dockerfile absolute path issue in V1

### DIFF
--- a/files/sysdig-inline-scan.sh
+++ b/files/sysdig-inline-scan.sh
@@ -534,7 +534,7 @@ post_analysis() {
 }
 
 get_scan_result() {
-    GET_CALL_STATUS=$(curl -s ${CURL_FLAGS} -o "${TMP_PATH}"/sysdig_report.log --write-out "%{http_code}" --header "Content-Type: application/json" -H "Authorization: Bearer ${SYSDIG_API_TOKEN}" "${SYSDIG_ANCHORE_URL}/images/${SYSDIG_IMAGE_DIGEST}/check?tag=${FULLTAG}&detail=${DETAIL}")
+    GET_CALL_STATUS=$(curl -s ${CURL_FLAGS} -o "${TMP_PATH}"/sysdig_report.log --write-out "%{http_code}" --header "Content-Type: application/json" -H "Authorization: Bearer ${SYSDIG_API_TOKEN}" "${SYSDIG_ANCHORE_URL}/images/${SYSDIG_IMAGE_DIGEST}/check?tag=${FULLTAG}&detail=${DETAIL}" || exit 0)
 }
 
 get_scan_result_with_retries() {
@@ -544,7 +544,11 @@ get_scan_result_with_retries() {
         if [[ "${GET_CALL_STATUS}" == 200 ]]; then
             return
         fi
-        print_info "." && sleep 1
+        if [[ "${GET_CALL_STATUS}" != 404 ]]; then
+            print_info "x" && sleep 10
+        else
+            print_info "." && sleep 1
+        fi
     done
     exit_with_error "Unable to fetch scan result"
 }

--- a/inline_scan.sh
+++ b/inline_scan.sh
@@ -54,7 +54,6 @@ fi
 
 display_usage() {
     cat << EOF
-
 Sysdig Inline Scanner/Analyzer --
 
   Wrapper script for performing vulnerability scan or image analysis on local docker images, utilizing the Sysdig inline_scan container.
@@ -67,7 +66,6 @@ EOF
 
 display_usage_analyzer() {
     cat << EOF
-
 Sysdig Inline Analyzer --
 
   Script for performing analysis on local container images, utilizing the Sysdig analyzer subsystem.
@@ -99,6 +97,11 @@ EOF
 main() {
     trap 'cleanup' EXIT ERR SIGTERM
     trap 'interupt' SIGINT
+
+    printf "**************************** DEPRECATION WARNING ****************************\n"
+    printf "You are using an old version of the Sysdig Inline Scanner. V2 is available.\n"
+    printf "Check https://github.com/sysdiglabs/secure-inline-scan for more information.\n"
+    printf "*****************************************************************************\n\n"
 
     if [[ "$#" -lt 1 ]] || { [[ "$1" != 'analyze' ]] && [[ "$1" != 'help' ]]; }; then
         display_usage >&2

--- a/tests/test_inline_scan_sh.py
+++ b/tests/test_inline_scan_sh.py
@@ -237,6 +237,14 @@ class InlineScanShellScript(unittest.TestCase):
         self.assertEqual(process_result.return_code, 2)
         self.assertIn("ERROR: must provide the Sysdig Secure API token", process_result.stderr)
 
+    def test_scan_with_http500_get_scan_result_api(self):
+        self.server.init_test(report_result="pass", return_error_500=2)
+        image_name_with_tag = "docker.io/alpine:3.10.3"
+        process_result = self.inline_scan(image_name_with_tag)
+        scan_result = self.check_output(process_result.stdout, image_name_with_tag)
+        self.check_scan_result(scan_result, process_result.return_code)
+        self.assertNotIn(f"docker.io/{image_name_with_tag}", process_result.stdout)
+
     @staticmethod
     def find_message_index_in_output(message, output_lines):
         for index, line in enumerate(output_lines):


### PR DESCRIPTION
* fix: improve curl error handling in v1 and v2, in case API returns an empty response.
* fix: handle Dockerfile (-f parameter) with absolute path correctly in script V1
