### PR TITLE
Print gates in human readable format instead of dumping the report JSON

### DIFF
--- a/files/sysdig-inline-scan.sh
+++ b/files/sysdig-inline-scan.sh
@@ -594,7 +594,10 @@ display_report() {
 
     print_info ""
     print_info "Scan Report"
-    #print_info_pipe < "${TMP_PATH}"/sysdig_report.log
+
+    if [[ "${v_flag:-}" ]]; then
+        print_info_pipe "  " < "${TMP_PATH}"/sysdig_report.log
+    fi
 
     # shellcheck disable=SC2016
     JQ_FORMAT=(

--- a/files/sysdig-inline-scan.sh
+++ b/files/sysdig-inline-scan.sh
@@ -590,7 +590,7 @@ get_scan_result_with_retries() {
 
 display_report() {
 
-    status=$(jq -r ".[0][][][0].status // empty" "${TMP_PATH}"/sysdig_report.log)
+    status=$(jq -r ".[0][][][0].status // empty" "${TMP_PATH}"/sysdig_report.log || echo "UNKNOWN")
 
     print_info ""
     print_info "Scan Report"
@@ -608,7 +608,7 @@ display_report() {
         '"Status:          " + .[0][][][0].status + "\n\n" +'
         '"Evaluation results\n" '
     )
-    print_info "$(jq -r "${JQ_FORMAT[*]}" "${TMP_PATH}"/sysdig_report.log)"
+    print_info "$(jq -r "${JQ_FORMAT[*]}" "${TMP_PATH}"/sysdig_report.log || echo "Error parsing scan report")"
 
     # shellcheck disable=SC2016
     JQ_FORMAT=(
@@ -620,7 +620,7 @@ display_report() {
         '($headers|index("Check_Output")) as $output_col | '
         '(.[0][][][0].detail.result.result[$image_id].result.rows[] | " - " + .[$action_col] + " " + .[$gate_col] + ":" + .[$trigger_col] + " " + .[$output_col])'
     )
-    print_info "$(jq -r "${JQ_FORMAT[*]}" "${TMP_PATH}"/sysdig_report.log)"
+    print_info "$(jq -r "${JQ_FORMAT[*]}" "${TMP_PATH}"/sysdig_report.log || echo "Error parsing scan report")"
     print_info ""
 
     if [[ "${r_flag-""}" ]]; then

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -80,7 +80,57 @@ class MockServer(Thread):
             report = [{
                 digest: {
                     tag: [{
-                        "status": self.report_result
+                        "status": self.report_result,
+                        "last_evaluation": "2020-10-29T17:18:50Z",
+                        "detail": {
+                            "result": {
+                                "final_action": "warn",
+                                "image_id": "imageid-xxxx",
+                                "result": {
+                                    "imageid-xxxx": {
+                                        "result": {
+                                            "final_action": "warn",
+                                            "image_id": "imageid-xxxx",
+                                            "header": [
+                                                "Image_Id",
+                                                "Repo_Tag",
+                                                "Trigger_Id",
+                                                "Gate",
+                                                "Trigger",
+                                                "Check_Output",
+                                                "Gate_Action",
+                                                "Whitelisted",
+                                                "Policy_Id"
+                                            ],
+                                            "rows": [
+                                                [
+                                                    "imageid-xxxx",
+                                                    tag,
+                                                    "41cb7cdf04850e33a11f80c42bf660b3",
+                                                    "mock-gate",
+                                                    "mock-trigger",
+                                                    "Gate output 1",
+                                                    "warn",
+                                                    False,
+                                                    "default"
+                                                ],
+                                                [
+                                                    "imageid-xxxx",
+                                                    tag,
+                                                    "1571e70ee221127984dcf585a56d4cff",
+                                                    "mock-gate",
+                                                    "mock-trigger",
+                                                    "Gate output 2",
+                                                    "warn",
+                                                    False,
+                                                    "default"
+                                                ]
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }]
                 }
             }]

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -14,7 +14,7 @@ class MockServer(Thread):
         self.app = Flask(__name__)
         self.app.config['TESTING'] = True
         self.url = "http://0.0.0.0:%s" % self.port
-        self.known_images = []
+        self.known_images = dict()
         self.report_result = "unknown"
         self.return_error_500 = 0
 
@@ -67,7 +67,7 @@ class MockServer(Thread):
         self.app.run(port=self.port)
 
     def handle_import(self):
-        self.known_images.append(request.headers["digestId"])
+        self.known_images[request.headers["digestId"]] = None
         request.files['archive_file'].read()
         return dict(code=0, message="OK", detail=dict())
 
@@ -77,63 +77,65 @@ class MockServer(Thread):
             return (dict(), 500)
         if digest in self.known_images:
             tag = request.args.get('tag')
-            report = [{
-                digest: {
-                    tag: [{
-                        "status": self.report_result,
-                        "last_evaluation": "2020-10-29T17:18:50Z",
-                        "detail": {
-                            "result": {
-                                "final_action": "warn",
-                                "image_id": "imageid-xxxx",
+            report = self.known_images[digest]
+            if report == None:
+                report = [{
+                    digest: {
+                        tag: [{
+                            "status": self.report_result,
+                            "last_evaluation": "2020-10-29T17:18:50Z",
+                            "detail": {
                                 "result": {
-                                    "imageid-xxxx": {
-                                        "result": {
-                                            "final_action": "warn",
-                                            "image_id": "imageid-xxxx",
-                                            "header": [
-                                                "Image_Id",
-                                                "Repo_Tag",
-                                                "Trigger_Id",
-                                                "Gate",
-                                                "Trigger",
-                                                "Check_Output",
-                                                "Gate_Action",
-                                                "Whitelisted",
-                                                "Policy_Id"
-                                            ],
-                                            "rows": [
-                                                [
-                                                    "imageid-xxxx",
-                                                    tag,
-                                                    "41cb7cdf04850e33a11f80c42bf660b3",
-                                                    "mock-gate",
-                                                    "mock-trigger",
-                                                    "Gate output 1",
-                                                    "warn",
-                                                    False,
-                                                    "default"
+                                    "final_action": "warn",
+                                    "image_id": "imageid-xxxx",
+                                    "result": {
+                                        "imageid-xxxx": {
+                                            "result": {
+                                                "final_action": "warn",
+                                                "image_id": "imageid-xxxx",
+                                                "header": [
+                                                    "Image_Id",
+                                                    "Repo_Tag",
+                                                    "Trigger_Id",
+                                                    "Gate",
+                                                    "Trigger",
+                                                    "Check_Output",
+                                                    "Gate_Action",
+                                                    "Whitelisted",
+                                                    "Policy_Id"
                                                 ],
-                                                [
-                                                    "imageid-xxxx",
-                                                    tag,
-                                                    "1571e70ee221127984dcf585a56d4cff",
-                                                    "mock-gate",
-                                                    "mock-trigger",
-                                                    "Gate output 2",
-                                                    "warn",
-                                                    False,
-                                                    "default"
+                                                "rows": [
+                                                    [
+                                                        "imageid-xxxx",
+                                                        tag,
+                                                        "41cb7cdf04850e33a11f80c42bf660b3",
+                                                        "mock-gate",
+                                                        "mock-trigger",
+                                                        "Gate output 1",
+                                                        "warn",
+                                                        False,
+                                                        "default"
+                                                    ],
+                                                    [
+                                                        "imageid-xxxx",
+                                                        tag,
+                                                        "1571e70ee221127984dcf585a56d4cff",
+                                                        "mock-gate",
+                                                        "mock-trigger",
+                                                        "Gate output 2",
+                                                        "warn",
+                                                        False,
+                                                        "default"
+                                                    ]
                                                 ]
-                                            ]
+                                            }
                                         }
                                     }
                                 }
                             }
-                        }
-                    }]
-                }
-            }]
+                        }]
+                    }
+                }]
             return (json.dumps(report), 200)
         else:
             return (dict(), 404)
@@ -145,7 +147,7 @@ class MockServer(Thread):
         print("MockServer:: Unhandled request {} /{}".format(request.method, path), file=sys.stderr)
         return ("", 500)
 
-    def init_test(self, known_images=[], report_result="unknown", return_error_500=0):
-        self.known_images = known_images
+    def init_test(self, known_images=None, report_result="unknown", return_error_500=0):
+        self.known_images = known_images or dict()
         self.report_result = report_result
         self.return_error_500 = return_error_500

--- a/tests/test_inline_scan_sh.py
+++ b/tests/test_inline_scan_sh.py
@@ -116,6 +116,21 @@ class InlineScanShellScript(unittest.TestCase):
         )
         self.check_scan_result(scan_result, process_result.return_code)
 
+    def test_scan_image_invalid_json_report(self):
+        self.server.init_test(report_result="pass", known_images={
+            "sha256:c5623df482648cacece4f9652a0ae04b51576c93773ccd43ad459e2a195906dd" : [{
+                    "sha256:c5623df482648cacece4f9652a0ae04b51576c93773ccd43ad459e2a195906dd": {
+                        "docker.io/python@sha256:c5623df482648cacece4f9652a0ae04b51576c93773ccd43ad459e2a195906dd": [{
+                            "status": "fail"
+                        }]
+                    }
+                }]
+            })
+        image_name = "docker.io/python@sha256:c5623df482648cacece4f9652a0ae04b51576c93773ccd43ad459e2a195906dd"
+        process_result = self.inline_scan(image_name)
+        self.assertIn("Error parsing scan report", process_result.stdout)
+        self.assertIn("Status is fail", process_result.stdout)
+
     @unittest.skip("not implemented")
     def test_scan_image_from_private_registry(self):
         raise NotImplementedError()
@@ -126,6 +141,7 @@ class InlineScanShellScript(unittest.TestCase):
         image_name_with_tag = "localbuild/{}".format(self.local_image_name_with_tag)
         scan_result = self.check_output(process_result.stdout, image_name_with_tag)
         self.check_scan_result(scan_result, process_result.return_code)
+
 
     def test_scan_with_clean_flag_pass_image(self):
         self.server.init_test(report_result="pass")

--- a/tests/test_inline_scan_sh.py
+++ b/tests/test_inline_scan_sh.py
@@ -265,7 +265,7 @@ class InlineScanShellScript(unittest.TestCase):
             else:
                 remaining_output_lines = remaining_output_lines[message_index:]
 
-        match = re.search(r'"status": "(?P<result>\w*)"', stdout)
+        match = re.search(r'Status:\s*(?P<result>\w*)', stdout)
         self.assertIsNotNone(match)
         scan_result = match.group('result')
 
@@ -274,8 +274,6 @@ class InlineScanShellScript(unittest.TestCase):
         self.assertEqual(scan_result, match.group('result'))
 
         self.assertIn(image_name_with_tag, stdout)
-        match = re.search(r'"status": "(?P<result>\w*)"', stdout)
-        self.assertIsNotNone(match)
 
         return scan_result
 


### PR DESCRIPTION
Instead of just dumping the JSON report, parse it using JQ and report a list of failed gates. Output example:

```
Inspecting image from remote repository -- docker.io/sysdig/agent:9.9.0
  Full image:  docker.io/sysdig/agent
  Full tag:    docker.io/sysdig/agent:9.9.0
  Repo digest: sha256:7cd23a94051e17b191b5cc5b4682ed9f3ece26b8283dc39b8a5b894462cec696
  Image id:    0c1a05d9fb4700de61b62d9969c0d29a4d59fd90cbf949cd916472bd860eb0e7
Image digest found on Sysdig Secure, skipping analysis.
Scan Report
Last Evaluation: 2020-10-29T19:22:10Z
Final action:    stop
Status:          fail
Evaluation results
 - warn dockerfile:instruction Dockerfile directive 'HEALTHCHECK' not found, matching condition 'not_exists' check
 - warn dockerfile:instruction Dockerfile directive 'USER' not found, matching condition 'not_exists' check
...
 - stop vulnerabilities:package HIGH Vulnerability found in non-os package type (python) - /usr/lib/python2.7/lib-dynload/Python (fixed in: 2.7.17, 3.6.10rc1, 3.7.5rc1, 3.8.0rc1)(VULNDB-212855 - http://anchore-api:8228/v1/query/vulnerabilities?id=VULNDB-212855)
 - stop vulnerabilities:package HIGH Vulnerability found in os package type (dpkg) - perl (fixed in: 5.28.1-6+deb10u1)(CVE-2020-10878 - https://security-tracker.debian.org/tracker/CVE-2020-10878)
 - stop vulnerabilities:package HIGH Vulnerability found in os package type (dpkg) - perl-base (fixed in: 5.28.1-6+deb10u1)(CVE-2020-
...
 - warn files:suid_or_guid_set SUID or SGID found set on file /var/local. Mode: 0o42775
 - warn files:suid_or_guid_set SUID or SGID found set on file /var/mail. Mode: 0o42775
 - warn dockerfile:effective_user User root found as effective user, which is explicity not allowed list
 - warn dockerfile:instruction Dockerfile directive 'USER' not found, matching condition 'not_exists' check
Status is fail
View the full result @ https://secure.sysdig.com/#/scanning/scan-results/docker.io%2Fsysdig%2Fagent%3A9.9.0/sha256:7cd23a94051e17b191b5cc5b4682ed9f3ece26b8283dc39b8a5b894462cec696/summaries
PDF report of the scan results can be generated with -r option.
```

The --format JSON flag still gets you a real JSON output, including the scan report.