### PR TITLE
Make TMP_PATH variable overridable by environment

### DIFF
--- a/files/sysdig-inline-scan.sh
+++ b/files/sysdig-inline-scan.sh
@@ -683,12 +683,6 @@ cleanup() {
         local ret="$1"
     fi
     set +e
-
-    if [[ "${v_flag:-}" ]]; then
-        print_info "Removing temporary folder created ${TMP_PATH}"
-    fi
-    rm -rf "${TMP_PATH}"
-
     exit "${ret}"
 }
 

--- a/files/sysdig-inline-scan.sh
+++ b/files/sysdig-inline-scan.sh
@@ -14,7 +14,7 @@ SCAN_IMAGE=""
 VALIDATED_OPTIONS=""
 # Vuln scan option variable defaults
 DOCKERFILE=""
-TMP_PATH="/tmp/sysdig"
+TMP_PATH=${TMP_PATH:-"/tmp/sysdig-inline-scan"}
 DEST_IMAGE_PATH="${TMP_PATH}/oci-image"
 # Analyzer option variable defaults
 SYSDIG_BASE_SCANNING_URL="https://secure.sysdig.com"
@@ -47,9 +47,9 @@ exit_with_error() {
 
 print_info() {
     if [[ -z "${silent_flag:-}" ]]; then
-        echo "$1" | tee -a ${TMP_PATH}/info.log
+        echo "$1" | tee -a "${TMP_PATH}/info.log"
     else
-        echo "$1" >> ${TMP_PATH}/info.log
+        echo "$1" >> "${TMP_PATH}/info.log"
     fi
 }
 
@@ -297,7 +297,6 @@ get_and_validate_analyzer_options() {
         fi
     fi
 
-    TMP_PATH="${TMP_PATH}/sysdig-inline-scan-$(date +%s)"
     mkdir -p "${TMP_PATH}"
     if [[ "${v_flag:-}" ]]; then
         print_info "Using temporary path ${TMP_PATH}"


### PR DESCRIPTION
As everything will run now inside a container, it does not make sense to create a random temporary folder for each execution, as the containers are not meant to be persistent.

Instead, use /tmp/sysdig-inline-scan as a hardcoded path, which will make it easier in case you want to mount an external volume in there (for example to tail the info.log file) and don't remove it when the analysis finishes, you the logs and reports are still available until the container is removed.

Also, if TMP_PATH is set, use it instead of the default value. This is handy for the inline-scan-service in case multiple analyses are run in parallel inside the same container. The inline-scan-service layer will set different TMP folders and launch different processes in parallel.